### PR TITLE
Fix money duplicate bug

### DIFF
--- a/src/main/java/studio/trc/bukkit/crazyauctionsplus/command/PluginCommand.java
+++ b/src/main/java/studio/trc/bukkit/crazyauctionsplus/command/PluginCommand.java
@@ -1352,7 +1352,7 @@ public class PluginCommand
                         if (!PluginControl.bypassTaxRate(player, ShopType.BUY)) {
                             tax = reward * PluginControl.getTaxRate(player, ShopType.BUY);
                         }
-                        if (CurrencyManager.getMoney(player) < reward) { 
+                        if (CurrencyManager.getMoney(player) < reward + tax) { 
                             HashMap<String, String> placeholders = new HashMap();
                             placeholders.put("%Money_Needed%", String.valueOf((reward + tax) - CurrencyManager.getMoney(player)));
                             placeholders.put("%money_needed%", String.valueOf((reward + tax) - CurrencyManager.getMoney(player)));


### PR DESCRIPTION
No sure if other side having some problem yet, but in there, If user having money which between `reward` and `reward+tax`, the money removing will not success and causing money duplicate.