### PR TITLE
Change EventPriority for ChatEvent

### DIFF
--- a/src/main/java/studio/trc/bukkit/crazyauctionsplus/event/GUIAction.java
+++ b/src/main/java/studio/trc/bukkit/crazyauctionsplus/event/GUIAction.java
@@ -804,7 +804,7 @@ public class GUIAction
         }
     }
     
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onRepricing(AsyncPlayerChatEvent e) {
         Player player = e.getPlayer();
         if (repricing.get(player.getUniqueId()) != null) {


### PR DESCRIPTION
Just a small change to fix a bug with Chat Plugin (I used mine) and because of the event priority "Monitor", my chat event react before yours and show the message in chat (the price when you want to reprice)

I put normal but I think the event priority can be lower since it's not cancellable and execute setCancelled(true)